### PR TITLE
Show reservation calendar in admin modal

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -51,7 +51,10 @@
         <h5 class="modal-title" id="reservLabel">Detalles de Reservación</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <div class="modal-body" id="reservDetails"></div>
+      <div class="modal-body">
+        <div id="reservDetails"></div>
+        <div id="reservCalendar" class="mt-3"></div>
+      </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
       </div>


### PR DESCRIPTION
## Summary
- display reservation calendar inside the admin modal
- initialize a second FullCalendar instance on the new container
- refresh the list and both calendars whenever a reservation is updated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688870c4f90c8326a6ea6900cf38ec18